### PR TITLE
Bugfixes and Spellchecking

### DIFF
--- a/jmat.js
+++ b/jmat.js
@@ -1501,7 +1501,6 @@ Jmat.Real.lambertw = function(x) {
         lastDir = -1;
       }
     }
-    return result;
   }
   return NaN;
 };


### PR DESCRIPTION
Making lints happy, fixing bugs.
Stuff fixed:
Missing semicolons
Spelling checked (except for names)

typeof 'array' -> typeof 'object' && Array.isArray() <- IE9+ support, earlier versions will need a polyfill.
defining / fixing undefined variables within:
Jmat.Real.eulerTotient: 'jmatresult' was not defined: Best guess was changing the variable to 'result'
Jmat.Complex.rootfind: 'z1' was not defined: Best guess was changing the variable to 'o.z1'
Jmat.Matrix.svd: 'i' was not defined: Best guess was a forgotten 'var' in for initializer.
Jmat.Matrix.solve: 'aag' was not defined: Best guess was a forgotten 'var' at assignment.
'Real, Complex, Matrix' were not defined: Best guess was a forgotten 'var' at assignment.

Jmat.Real.lambertw: 'return result' after for(;;) loop was unreachable because the only exit conditions from the loop were 'return result's. Removed.
Jmat.Complex.polylog_integral_: argument 's' has no method 'divrdivr'. Renamed to divr.

Remaining issues:
Jmat.Complex.doSummation: i is not defined
Jmat.Complex.doProduct: i is not defined
Jmat.Complex.polylog: final return: 'return Jmat.Complex(NaN);' is unreachable due to an if else chain ending with an else containing a return. I am unsure how you wish to proceed there.
Jmat.Complex.gamma_inv: 'x' may not have been initialized before the first expression.

You might be experiencing type coercion issues with != or == against 0, "", undefined, and null. To exactly match the intended object, use !== or === instead.
